### PR TITLE
Strong name sign `Microsoft.DotNet.Build.Tasks.Feed.dll`

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SignAssembly>false</SignAssembly>
     <Description>This package provides support for publishing assets to appropriate channels.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsBuildTaskProject>true</IsBuildTaskProject>


### PR DESCRIPTION
This change is required by [dotnet/dotnet#1811](https://github.com/dotnet/dotnet/pull/1811)

According to the [Arcade documentation](https://github.com/dotnet/arcade/blob/f2cdf946c00a12a2c283835bb41ddc2255832055/Documentation/ArcadeSdk.md?plain=1#L951-L955), assemblies must have SignAssembly set to true in order to be strong-name signed.

The following file ends up in the previously source-built artifacts and must be strong-name signed to avoid issues:

```
Private.SourceBuilt.Artifacts.10.0.100-rc.1.25422.104.centos.10-x64.tar.gz/Microsoft.DotNet.Build.Tasks.Feed.10.0.0-beta.25422.104.nupkg/tools/net/Microsoft.DotNet.Build.Tasks.Feed.dll: Outcome="Unsigned" AuthentiCode="Timestamp: 08/22/25 17:03:13 (sha256RSA), AuthentiCode signed: True" StrongName="StrongName signed: False
```